### PR TITLE
Updated axruntime.md - Added available properties

### DIFF
--- a/docs/reference/axruntime.md
+++ b/docs/reference/axruntime.md
@@ -341,7 +341,24 @@ AXR_EXPORT axrResult axr_configure_device (
 
 * `context` the context
 * `device` the device to configure
-* `properties` the options to change. Currently supported options are clock\_profile:int - the clock profile to use, frequency in MHz.
+* `properties` the options to change.
+  
+|    Supported options   |
+| ---------------------- |
+| sw_throttling          |
+| mvm_utilisation_core_3 |
+| pvt_warning_threshold  |
+| clock_profile_core_3   |
+| hw_throttling          |
+| mvm_utilisation_core_2 |
+| clock_profile_core_2   |
+| mvm_utilisation_core_1 |
+| clock_profile_core_1   |
+| clock_profile_core_0   |
+| mvm_utilisation_core_0 |
+| clock_profile          |
+| ddr_size               |
+  
 
 
 **Returns:**

--- a/docs/reference/axruntime.md
+++ b/docs/reference/axruntime.md
@@ -343,22 +343,24 @@ AXR_EXPORT axrResult axr_configure_device (
 * `device` the device to configure
 * `properties` the options to change.
   
-|    Supported options   |
-| ---------------------- |
-| sw_throttling          |
-| mvm_utilisation_core_3 |
-| pvt_warning_threshold  |
-| clock_profile_core_3   |
-| hw_throttling          |
-| mvm_utilisation_core_2 |
-| clock_profile_core_2   |
-| mvm_utilisation_core_1 |
-| clock_profile_core_1   |
-| clock_profile_core_0   |
-| mvm_utilisation_core_0 |
-| clock_profile          |
-| ddr_size               |
-  
+|    Supported options   |  Format (type) |
+| ---------------------- | -------------- |
+| sw_throttling          |      T:H:L     |
+| mvm_utilisation_core_3 |       int      |
+| pvt_warning_threshold  |       int      |
+| clock_profile_core_3   |       int      |
+| hw_throttling          |       T:H      |
+| mvm_utilisation_core_2 |       int      |
+| clock_profile_core_2   |       int      |
+| mvm_utilisation_core_1 |       int      |
+| clock_profile_core_1   |       int      |
+| clock_profile_core_0   |       int      |
+| mvm_utilisation_core_0 |       int      |
+| clock_profile          |       int      |
+| ddr_size               |       int      |
+
+**_NOTE!_** \
+**_Although `ddr_size` option appears and it IS an integer, it is not recognised by the parser when used._**
 
 
 **Returns:**

--- a/docs/reference/axruntime.md
+++ b/docs/reference/axruntime.md
@@ -360,7 +360,12 @@ AXR_EXPORT axrResult axr_configure_device (
 | ddr_size               |       int      |
 
 **_NOTE!_** \
-**_Although `ddr_size` option appears and it IS an integer, it is not recognised by the parser when used._**
+**_Although `ddr_size` option appears and it IS an integer, it is not recognised by the parser when used._** \
+These options can be found using the `axr_read_device_configuration()` on a discovered device. \
+All these options are contained in the axrProperties return value and can be converted to a string with the `axr_list_properties()`.
+
+Tested on `Metis M.2` the string is this:
+`sw_throttling;mvm_utilisation_core_3;pvt_warning_threshold;clock_profile_core_3;hw_throttling;mvm_utilisation_core_2;clock_profile_core_2;mvm_utilisation_core_1;clock_profile_core_1;clock_profile_core_0;mvm_utilisation_core_0;clock_profile;ddr_size`
 
 
 **Returns:**


### PR DESCRIPTION
Adding a table with all the available property options In axruntime.md file, at axr_configure_device section.
The only documented one was the clock_profile.
ddr_size is not recognized by the parser if try to configure a device using it. I guess it is because it is read only.