### PR TITLE
Jetson: opt‑in explicit demux/parse/decode for VIDEO_FILE; codec-aware fallback; keep decodebin default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ at different levels of abstraction.
 The InferenceStream library is the easiest to use and enables most users to achieve the highest performance. The lower-level APIs enable expert users
 to integrate Metis within existing video streaming frameworks.
 
+Tip for Jetson users: If you see GStreamer negotiation errors when playing MP4/H.264 files (for example, capsfilter not-negotiated), set the environment variable AXELERA_GST_EXPLICIT_PARSE=1 before running inference. This enables an explicit demux/parse/decode chain optimized for Jetson (qtdemux → h264parse → decoder), which resolves common decodebin issues on NVIDIA platforms.
+
 ## Reference pipelines
 
 The Voyager SDK makes it easy to construct pipelines that combine multiple models in different ways. A number of

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The Voyager SDK makes it easy to build high-performance inferencing applications
 | [Inferencing manual (`inference.py`)](/docs/reference/inference.md) | Explains all options provided by command-line interencing tool |
 | [Application integration tutorial (high level)](/docs/tutorials/application.md) | Explains how to integrate a YAML pipeline within your application |
 | [Application integration tutorial (low level)](/docs/tutorials/axinferencenet.md) | Explains how to integrate an AxInferenceNet model within your application |
+| [Jetson GStreamer video guide](/docs/tutorials/jetson_gstreamer_video.md) | How to resolve MP4/H.264 negotiation issues and enable explicit parse on Jetson |
 
 ## Application integration APIs
 
@@ -60,7 +61,7 @@ at different levels of abstraction.
 The InferenceStream library is the easiest to use and enables most users to achieve the highest performance. The lower-level APIs enable expert users
 to integrate Metis within existing video streaming frameworks.
 
-Tip for Jetson users: If you see GStreamer negotiation errors when playing MP4/H.264 files (for example, capsfilter not-negotiated), set the environment variable AXELERA_GST_EXPLICIT_PARSE=1 before running inference. This enables an explicit demux/parse/decode chain optimized for Jetson (qtdemux → h264parse → decoder), which resolves common decodebin issues on NVIDIA platforms.
+Tip for Jetson users: If you see GStreamer negotiation errors when playing MP4/H.264 files (for example, capsfilter not-negotiated), set the environment variable AXELERA_GST_EXPLICIT_PARSE=1 before running inference. This enables an explicit demux/parse/decode chain optimized for Jetson (qtdemux → h264parse → decoder), which resolves common decodebin issues on NVIDIA platforms. See the [Jetson GStreamer video guide](/docs/tutorials/jetson_gstreamer_video.md) for details.
 
 ## Reference pipelines
 

--- a/axelera/app/gst_builder.py
+++ b/axelera/app/gst_builder.py
@@ -125,6 +125,18 @@ class _OldBuilder(list):
         ...
 
     @element
+    def nvvidconv(self, props={}, **kwargs) -> None:
+        ...
+
+    @element
+    def avdec_h264(self, props={}, **kwargs) -> None:
+        ...
+
+    @element
+    def avdec_h265(self, props={}, **kwargs) -> None:
+        ...
+
+    @element
     def playbin(self, props={}, **kwargs) -> None:
         ...
 

--- a/axelera/app/pipe/io.py
+++ b/axelera/app/pipe/io.py
@@ -451,7 +451,7 @@ class SinglePipeInput(PipeInput):
         elif self._src.type in (config.SourceType.IMAGE_FILES, config.SourceType.DATA_SOURCE):
             _build_data_loader(gst)
             gst.images = [os.path.relpath(str(i), os.getcwd()) for i in self._src.images]
-    elif self._src.type == config.SourceType.VIDEO_FILE:
+        elif self._src.type == config.SourceType.VIDEO_FILE:
             # Optionally build an explicit demux/parse/decode chain for file sources to avoid
             # decodebin negotiation issues seen on Jetson/NVIDIA pipelines.
             # Enable with AXELERA_GST_EXPLICIT_PARSE=1

--- a/axelera/app/pipe/io.py
+++ b/axelera/app/pipe/io.py
@@ -7,6 +7,8 @@ import dataclasses
 import enum
 import os
 from pathlib import Path
+import shutil
+import subprocess
 import re
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Tuple
 import urllib
@@ -449,7 +451,7 @@ class SinglePipeInput(PipeInput):
         elif self._src.type in (config.SourceType.IMAGE_FILES, config.SourceType.DATA_SOURCE):
             _build_data_loader(gst)
             gst.images = [os.path.relpath(str(i), os.getcwd()) for i in self._src.images]
-        elif self._src.type == config.SourceType.VIDEO_FILE:
+    elif self._src.type == config.SourceType.VIDEO_FILE:
             # Optionally build an explicit demux/parse/decode chain for file sources to avoid
             # decodebin negotiation issues seen on Jetson/NVIDIA pipelines.
             # Enable with AXELERA_GST_EXPLICIT_PARSE=1
@@ -461,32 +463,71 @@ class SinglePipeInput(PipeInput):
             )
             gst.filesrc(location=self._src.location)
             if use_explicit_parse:
-                # filesrc → qtdemux (video_%u) → h264parse → decoder → decodebin-linkX
-                # Route qtdemux dynamic video pad to the parser sink
-                gst.qtdemux(connections={'video_%u': f'videoparser{stream_idx or 0}.sink'})
-                # Parser converts avc1 stream format from MP4 to byte-stream
-                gst.h264parse(
-                    name=f'videoparser{stream_idx or 0}',
-                    connections={'src': f'videodecoder{stream_idx or 0}.sink'},
-                )
+                # Detect codec to decide whether to use explicit parse (h264/h265) or fall back to decodebin
+                codec = ''
+                if shutil.which('ffprobe'):
+                    try:
+                        out = subprocess.run(
+                            [
+                                'ffprobe',
+                                '-v',
+                                'error',
+                                '-select_streams',
+                                'v:0',
+                                '-show_entries',
+                                'stream=codec_name',
+                                '-of',
+                                'default=nw=1:nk=1',
+                                self._src.location,
+                            ],
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                        )
+                        codec = (out.stdout or '').strip().lower()
+                    except Exception:
+                        codec = ''
 
-                # Choose decoder: prefer hardware if enabled, otherwise software
-                if self._allow_hardware_codec:
-                    # Jetson decoder outputs NVMM memory; convert to system memory for downstream
-                    gst.nvv4l2decoder(name=f'videodecoder{stream_idx or 0}')
-                    # Convert from NVMM to system memory
-                    gst.nvvidconv()
-                    # Force system memory raw frames (drop NVMM) and keep NV12 to minimize copies
-                    gst.capsfilter(
-                        caps='video/x-raw,format=NV12',
-                        connections={'src': f'decodebin-link{stream_idx or 0}.sink'},
-                    )
+                is_h264 = codec in ('h264', 'avc1')
+                is_h265 = codec in ('hevc', 'h265', 'hev1', 'hvc1')
+
+                if not (is_h264 or is_h265):
+                    # Unknown/unsupported for explicit path – fall back to legacy decodebin
+                    requires_decodebin = True
                 else:
-                    gst.avdec_h264(
-                        name=f'videodecoder{stream_idx or 0}',
-                        connections={'src': f'decodebin-link{stream_idx or 0}.sink'},
-                    )
-                requires_decodebin = False
+                    # filesrc → qtdemux (video_%u) → h26x parse → decoder → decodebin-linkX
+                    gst.qtdemux(connections={'video_%u': f'videoparser{stream_idx or 0}.sink'})
+                    if is_h265:
+                        gst.h265parse(
+                            name=f'videoparser{stream_idx or 0}',
+                            connections={'src': f'videodecoder{stream_idx or 0}.sink'},
+                        )
+                    else:
+                        gst.h264parse(
+                            name=f'videoparser{stream_idx or 0}',
+                            connections={'src': f'videodecoder{stream_idx or 0}.sink'},
+                        )
+
+                    # Choose decoder: prefer hardware if enabled, otherwise software
+                    if self._allow_hardware_codec:
+                        gst.nvv4l2decoder(name=f'videodecoder{stream_idx or 0}')
+                        gst.nvvidconv()
+                        gst.capsfilter(
+                            caps='video/x-raw,format=NV12',
+                            connections={'src': f'decodebin-link{stream_idx or 0}.sink'},
+                        )
+                    else:
+                        if is_h265:
+                            gst.avdec_h265(
+                                name=f'videodecoder{stream_idx or 0}',
+                                connections={'src': f'decodebin-link{stream_idx or 0}.sink'},
+                            )
+                        else:
+                            gst.avdec_h264(
+                                name=f'videodecoder{stream_idx or 0}',
+                                connections={'src': f'decodebin-link{stream_idx or 0}.sink'},
+                            )
+                    requires_decodebin = False
             else:
                 # Legacy/default behaviour: rely on decodebin auto-plugging
                 requires_decodebin = True

--- a/axelera/app/pipe/io.py
+++ b/axelera/app/pipe/io.py
@@ -241,11 +241,31 @@ def build_decodebin(gst: gst_builder.Builder, allow_hardware_codec, stream_idx):
     hw_decoder = allow_hardware_codec
     props = {
         'force-sw-decoders': not hw_decoder,
+        # Keep caps aligned with existing golden pipelines/tests
         'caps': 'video/x-raw(ANY)',
         'expose-all-streams': False,
     }
     props['connections'] = {'src_%u': f'decodebin-link{stream_idx or 0}.sink'}
     gst.decodebin(props)
+
+
+def build_jetson_video_decode(gst: gst_builder.Builder, stream_idx):
+    """Build a Jetson-optimized video decode pipeline for MP4/MOV files.
+    
+    NVIDIA nvv4l2decoder requires byte-stream format, but MP4 files contain
+    AVC1/HVC1 format. We need to explicitly insert h264parse/h265parse to
+    convert the stream format, which decodebin doesn't do automatically.
+    """
+    # qtdemux extracts video stream from MP4/MOV container
+    # video_%u is a dynamic pad - the SDK will use pad-added callback to link it
+    gst.qtdemux(connections={'video_%u': f'videoparser{stream_idx or 0}.sink'})
+    
+    # h264parse converts from AVC1 to byte-stream format required by nvv4l2decoder
+    # Note: For H.265 videos, this would need h265parse instead
+    gst.h264parse(name=f'videoparser{stream_idx or 0}')
+    
+    # NVIDIA hardware decoder
+    gst.nvv4l2decoder(connections={'src': f'decodebin-link{stream_idx or 0}.sink'})
 
 
 def _build_gst_usb(gst: gst_builder.Builder, src: config.Source, allow_hardware_codec, stream_idx):
@@ -430,8 +450,46 @@ class SinglePipeInput(PipeInput):
             _build_data_loader(gst)
             gst.images = [os.path.relpath(str(i), os.getcwd()) for i in self._src.images]
         elif self._src.type == config.SourceType.VIDEO_FILE:
+            # Optionally build an explicit demux/parse/decode chain for file sources to avoid
+            # decodebin negotiation issues seen on Jetson/NVIDIA pipelines.
+            # Enable with AXELERA_GST_EXPLICIT_PARSE=1
+            use_explicit_parse = str(os.getenv('AXELERA_GST_EXPLICIT_PARSE', '0')).lower() in (
+                '1',
+                'true',
+                'yes',
+                'on',
+            )
             gst.filesrc(location=self._src.location)
-            requires_decodebin = True
+            if use_explicit_parse:
+                # filesrc → qtdemux (video_%u) → h264parse → decoder → decodebin-linkX
+                # Route qtdemux dynamic video pad to the parser sink
+                gst.qtdemux(connections={'video_%u': f'videoparser{stream_idx or 0}.sink'})
+                # Parser converts avc1 stream format from MP4 to byte-stream
+                gst.h264parse(
+                    name=f'videoparser{stream_idx or 0}',
+                    connections={'src': f'videodecoder{stream_idx or 0}.sink'},
+                )
+
+                # Choose decoder: prefer hardware if enabled, otherwise software
+                if self._allow_hardware_codec:
+                    # Jetson decoder outputs NVMM memory; convert to system memory for downstream
+                    gst.nvv4l2decoder(name=f'videodecoder{stream_idx or 0}')
+                    # Convert from NVMM to system memory
+                    gst.nvvidconv()
+                    # Force system memory raw frames (drop NVMM) and keep NV12 to minimize copies
+                    gst.capsfilter(
+                        caps='video/x-raw,format=NV12',
+                        connections={'src': f'decodebin-link{stream_idx or 0}.sink'},
+                    )
+                else:
+                    gst.avdec_h264(
+                        name=f'videodecoder{stream_idx or 0}',
+                        connections={'src': f'decodebin-link{stream_idx or 0}.sink'},
+                    )
+                requires_decodebin = False
+            else:
+                # Legacy/default behaviour: rely on decodebin auto-plugging
+                requires_decodebin = True
         else:
             raise NotImplementedError(f"{self._src.type} format not supported in gst pipe")
 

--- a/docs/tutorials/jetson_gstreamer_video.md
+++ b/docs/tutorials/jetson_gstreamer_video.md
@@ -1,0 +1,77 @@
+# Jetson guide: reliable MP4/H.264 video with GStreamer
+
+On NVIDIA Jetson devices, GStreamer decodebin may fail to autoplug the required parser for MP4 (avc1) H.264 streams, causing caps negotiation errors like "capsfilter not-negotiated" or qtdemux streaming errors.
+
+This guide shows how to enable a reliable demux/parse/decode chain in Voyager SDK and validate your setup.
+
+## TL;DR
+
+If you see negotiation errors when playing MP4/H.264 files, enable the explicit chain:
+
+```bash
+AXELERA_GST_EXPLICIT_PARSE=1 ./inference.py <model-yaml-or-alias> <video.mp4> --aipu-cores 4
+```
+
+This switches VIDEO_FILE inputs from decodebin to an explicit pipeline:
+
+- filesrc → qtdemux(video_%u) → h264parse → decoder → (nvvidconv if HW) → capsfilter(video/x-raw,format=NV12) → …
+
+Notes:
+- Software decode (avdec_h264) is used unless you enable hardware decoders in your run.
+- Hardware decode (nvv4l2decoder) outputs NVMM memory; we convert to system memory via nvvidconv + caps.
+
+## Why this helps
+
+- MP4 containers often carry H.264 in avc1 format; many hardware decoders require byte-stream format.
+- decodebin doesn’t always insert h264parse for avc1 on Jetson, leading to not-negotiated errors.
+- Inserting qtdemux + h264parse explicitly ensures the stream is converted for the decoder.
+
+## Verify your environment
+
+Optional checks (diagnostic only):
+
+```bash
+# Confirm NVIDIA decoder and converter are present
+gst-inspect-1.0 nvv4l2decoder | grep -E 'Sink|Src|NVMM' -n || true
+gst-inspect-1.0 nvvidconv | head -n 20 || true
+
+# See codec info (H.264 avc1) for your video
+ffprobe -hide_banner -v error -select_streams v:0 -show_entries stream=codec_name,profile,codec_tag_string -of default=nk=1:nw=1 <video.mp4>
+```
+
+## Run examples
+
+- Software decode (recommended for stability):
+
+```bash
+AXELERA_GST_EXPLICIT_PARSE=1 ./inference.py yolov8s-coco-onnx ./media/traffic3_480p.mp4 --aipu-cores 4 --no-display --frames 30
+```
+
+- Hardware decode (optional; may depend on Jetson image/plugins):
+
+```bash
+AXELERA_GST_EXPLICIT_PARSE=1 ./inference.py yolov8s-coco-onnx ./media/traffic3_1080p.mp4 --aipu-cores 4
+```
+
+If you encounter instability with the NVIDIA plugins, try the software decode first to confirm decoding and negotiation are okay.
+
+## Behavior details
+
+- Default behavior remains decodebin for backward compatibility and testing.
+- Setting AXELERA_GST_EXPLICIT_PARSE=1 enables the explicit chain for VIDEO_FILE inputs only.
+- RTSP/USB/HLS paths are unchanged.
+
+## Troubleshooting
+
+- Still seeing not-negotiated?
+  - Ensure the env var is set in the same shell invocation as inference.
+  - Try the software path first (don’t enable hardware decoder flags).
+  - Check that your GStreamer has h264parse and qtdemux elements.
+- HW decode crashes or times out?
+  - Use software decode as a baseline; investigate Jetson plugin versions (nvv4l2decoder/nvvidconv) and caps.
+
+## Contributing upstream
+
+- The change is opt-in to avoid breaking existing golden YAMLs.
+- Propose a PR with these changes and include brief logs and pipeline snippets demonstrating the fix on Jetson.
+- Optionally add a CLI flag in the future (e.g., `--explicit-parse`) to replace the env var.


### PR DESCRIPTION

**Motivation**

On Jetson/NVIDIA, decodebin often fails to autoplug h264parse for MP4 (avc1) H.264, causing caps negotiation failures (e.g., capsfilter not-negotiated, qtdemux streaming stopped).
We provide an explicit demux/parse/decode chain that reliably negotiates on Jetson while keeping the legacy default for backward-compatibility and golden YAML stability.

**Changes**

VIDEO_FILE input: add env var AXELERA_GST_EXPLICIT_PARSE=1 to switch from decodebin to:
filesrc → qtdemux(video_%u) → h264parse → decoder → (nvvidconv if HW) → caps(video/x-raw,format=NV12) → decodebin-linkX
Default remains legacy decodebin with caps video/x-raw(ANY) to preserve existing tests/golden pipelines.
Add GStreamer builder wrappers:
avdec_h264, avdec_h265 (software decoders)
nvvidconv (NVMM → system memory conversion)
HW path: nvv4l2decoder → nvvidconv → caps(video/x-raw,format=NV12) to drop NVMM for downstream elements.
Docs:
README: Jetson tip + link to a detailed guide
New: jetson_gstreamer_video.md with instructions and troubleshooting
Files touched

io.py
gst_builder.py
README.md
jetson_gstreamer_video.md
Backward compatibility

Default behavior unchanged; decodebin path and YAML structure remain the same.
Unit tests and golden YAMLs are preserved.

**Validation**

With AXELERA_GST_EXPLICIT_PARSE=1:
traffic3_480p.mp4 and traffic3_1080p.mp4 run without negotiation errors.
Software decode path (avdec_h264) stable.
Hardware decode path (nvv4l2decoder + nvvidconv) links correctly; stability may depend on Jetson image/plugin versions.

Preliminary results look good:
$ AXELERA_GST_EXPLICIT_PARSE=1 ./inference.py yolov8s-coco-onnx ./media/traffic3_1080p.mp4 --aipu-cores 4 --no-display
2025-11-05 15:54:23.460595147 [W:onnxruntime:Default, device_discovery.cc:164 DiscoverDevicesForPlatform] GPU device discovery failed: device_discovery.cc:89 ReadFileContents Failed to open file: "/sys/class/drm/card1/device/vendor"
WARNING : No OpenCL GPU devices found
WARNING : Please check the documentation for installation instructions
INFO    : Interrupting the inference stream                                                                 ^C
Core Temp  : 48.0°C                                                                                         
CPU %      : 28.3%
End-to-end : 43.7fps
Latency    : 452.5ms (min:407.2 max:534.4 σ:24.9 x̄:446.3)ms


<img width="1857" height="1056" alt="Screenshot from 2025-11-05 15-53-16" src="https://github.com/user-attachments/assets/c00a07c8-b3b8-4cda-82d1-b52d7554a377" />

**Follow‑ups (optional)**

Add a CLI flag (e.g., --explicit-parse) as a friendly alternative to the env var.
Auto-detect H.265 to choose h265parse/avdec_h265 when needed.


