### PR TITLE
fix(operators): removes threshold for multi-class semantic seg

### DIFF
--- a/operators/src/AxDecodeSemanticSeg.cpp
+++ b/operators/src/AxDecodeSemanticSeg.cpp
@@ -46,7 +46,7 @@ decode_to_meta(const AxTensorsInterface &in_tensors, const semantic_seg::propert
         } else {
           std::span<float> vec(fdata + offset, tensor.sizes[3]);
           auto max_it = std::max_element(vec.begin(), vec.end());
-          *out_it++ = *max_it > prop->threshold ? std::distance(vec.begin(), max_it) : -1;
+          *out_it++ = std::distance(vec.begin(), max_it);
         }
         offset += tensor.sizes[3];
       }


### PR DESCRIPTION
The behavior of the Semantic Segmentation decoder is inconsistent between the Python and C++ implementations.

The Python operator (`axelera/app/operators/postprocessing.py`, class `SemanticSegmentation`) applies thresholding only for binary segmentation.

In contrast, the C++ operator (`operators/src/AxDecodeSemanticSeg.cpp`) applies thresholding to both binary and multi-class segmentation outputs.

Applying a threshold to multi-class outputs is incorrect and leads to inconsistent results when switching between the Torch preprocessing pipeline and the GStreamer pipeline.

This pull request removes thresholding from the C++ operator for multi-class segmentation, aligning its behavior with the Python implementation.